### PR TITLE
Fix erase mode for fill tool

### DIFF
--- a/Sources/Core/Pix2d.Shared/Primitives/Drawing/BrushDrawingMode.cs
+++ b/Sources/Core/Pix2d.Shared/Primitives/Drawing/BrushDrawingMode.cs
@@ -7,6 +7,7 @@
         Select,
         MoveSelection,
         ExternalDraw,
-        Fill
+        Fill,
+        FillErase,
     }
 }

--- a/Sources/Core/Pix2d/Plugins/Drawing/Tools/FillTool.cs
+++ b/Sources/Core/Pix2d/Plugins/Drawing/Tools/FillTool.cs
@@ -18,11 +18,23 @@ public class FillTool : BaseTool, IDrawingTool
     
     public IDrawingService DrawingService { get; }
     private readonly IPixelBrush _previewBrush = new SquareSolidBrush();
+    private bool _eraseMode;
 
-    public virtual BrushDrawingMode DrawingMode => BrushDrawingMode.Fill;
+    public virtual BrushDrawingMode DrawingMode => EraseMode ? BrushDrawingMode.FillErase : BrushDrawingMode.Fill;
 
     public override EditContextType EditContextType => EditContextType.Sprite;
     public override string DisplayName => ToolSettings.DisplayName;
+
+    public bool EraseMode
+    {
+        get => _eraseMode;
+        set
+        {
+            _eraseMode = value;
+            if (IsActive)
+                DrawingService.DrawingLayer.SetDrawingLayerMode(DrawingMode);
+        }
+    }
 
     public FillTool(IDrawingService drawingService)
     {

--- a/Sources/Core/Pix2d/Views/ToolBar/ToolSettingsContainerView.cs
+++ b/Sources/Core/Pix2d/Views/ToolBar/ToolSettingsContainerView.cs
@@ -14,7 +14,7 @@ public class ToolSettingsContainerView : ComponentBase
         new FuncDataTemplate<EraserTool>((vm, ns) => new Grid());
 
     public IDataTemplate FillToolSettingsTemplate { get; } =
-        new FuncDataTemplate<FillTool>((vm, ns) => new FillToolSettingsView());
+        new FuncDataTemplate<FillTool>((vm, ns) => new FillToolSettingsView(vm));
 
     public IDataTemplate PixelSelectToolSettingsTemplate { get; } =
         new FuncDataTemplate<PixelSelectTool>((vm, ns) => new SelectionToolSettingsView());

--- a/Sources/Core/Pix2d/Views/ToolBar/Tools/FillToolSettingsView.cs
+++ b/Sources/Core/Pix2d/Views/ToolBar/Tools/FillToolSettingsView.cs
@@ -1,51 +1,20 @@
-﻿using SkiaSharp;
+﻿using Pix2d.Plugins.Drawing.Tools;
+using SkiaSharp;
 
 namespace Pix2d.Views.ToolBar.Tools;
 
-public class FillToolSettingsView : ComponentBase
+public class FillToolSettingsView : ViewBase<FillTool>
 {
-    protected override object Build() =>
+    protected override object Build(FillTool vm) =>
         new StackPanel()
             .Margin(8)
             .Children(
-                new TextBlock()
-                    .Text("Erase mode"),
                 new ToggleSwitch()
-                    .IsChecked(false)
+                    .Content("Erase mode")
+                    .IsChecked(vm.EraseMode , BindingMode.TwoWay, bindingSource: vm)
             );
 
-    private SKColor _lastColor;
-
-    [Inject] IDrawingService DrawingService { get; set; } = null!;
-    [Inject] AppState AppState { get; set; } = null!;
-    public DrawingState DrawingState => AppState.DrawingState;
-
-    public bool EraseMode { get; set; }
-
-    private void SetEraseMode(bool value)
+    public FillToolSettingsView(FillTool viewModel) : base(viewModel)
     {
-        if (value)
-        {
-            _lastColor = DrawingState.CurrentColor;
-            DrawingService.SetCurrentColor(SKColor.Empty);
-        }
-        else
-            DrawingService.SetCurrentColor(_lastColor);
-    }
-
-    public void Activated()
-    {
-        _lastColor = DrawingState.CurrentColor;
-
-        if (EraseMode)
-        {
-            DrawingService.SetCurrentColor(SKColor.Empty);
-        }
-    }
-
-    public void Deactivated()
-    {
-        if (EraseMode)
-            DrawingService.SetCurrentColor(_lastColor);
     }
 }


### PR DESCRIPTION
This PR does 2 things:
1. Fixes the Erase mode button.
2. Fixes logic behind how the erase mode works.

Before the change, erase mode switch modified the selected color in drawing service, which had unwanted side effects:
* the selected color in color picker changed (and stayed changed even when the fill tool is deactivated)
* if the color is changed by user, erase mode broke, and then after erase mode is disabled, the color selected by user was reset to the active color at the moment when erase mode was enabled

To prevent this and make working of the tool consistent, I added a new drawing mode FillErase, which simplified things a lot. I also moved all the logic (which is not much) from the settings view to the fill tool, so that all the logic would be in the same place.

At this point the conditional statements in DrawingLayerNode about DrawingState ask for refactoring but I suggest we do it later, because I still don't fully understand how it works...

Fixes #121 